### PR TITLE
Update nextConfig to use remotePatterns for image domains

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,8 +1,15 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
-    domains: ['utfs.io'],
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'utfs.io',
+        port: '',
+        pathname: '**/*',
+      },
+    ],
   },
-}
+};
 
-export default nextConfig
+export default nextConfig;


### PR DESCRIPTION
This pull request updates the image configuration in the nextConfig file to use remotePatterns instead of specifying domains directly. This new configuration recommended by the Nextjs which allows for more flexible matching of image URLs by defining patterns that include protocol, hostname, port, and pathname. This change is specifically aimed at accommodating the https://utfs.io domain with any path structure. This update is beneficial for handling a wider range of remote images and future-proofs the configuration for potential domain changes or additional image sources.