### PR TITLE
Update the Toast error message title in /upload/page.tsx

### DIFF
--- a/src/app/configure/upload/page.tsx
+++ b/src/app/configure/upload/page.tsx
@@ -33,7 +33,7 @@ const Page = () => {
     setIsDragOver(false)
 
     toast({
-      title: `${file.file.type} type is not supported.`,
+      title: `${file.file.type ? file.file.type : 'Your file '} type is not supported.`,
       description: "Please choose a PNG, JPG, or JPEG image instead.",
       variant: "destructive"
     })


### PR DESCRIPTION
Problem:
When the user uploads a file with a type other than PNG, JPG, or JPEG, we give the user an error message with the wrong file type. This works for known file types like JSON, for example, but for the "not so common" ones like.deb, for example, dropzone returns an empty string, so the error message will be "type is not supported."

Solution:
Change the title error message of the toast to include a generic error message for file types that's not detected by dropzone.

generic error message: "Your file type is not supported."