### PR TITLE
Allow Icons component receive a className without type error

### DIFF
--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -1,8 +1,11 @@
 import { LucideProps } from 'lucide-react'
 
 export const Icons = {
-  underline: (props: LucideProps) => (
-    <svg {...props} viewBox='0 0 687 155'>
+  underline: ({
+    className,
+    ...props
+  }: LucideProps & { className?: string }) => (
+    <svg {...props} className={className} viewBox='0 0 687 155'>
       <g
         stroke='currentColor'
         strokeWidth='7'


### PR DESCRIPTION
There is a type error when trying to add a className to the Icons component, we can add the className optional prop to the Icons component so we can receive the classname without any problems.

Note: The styles work fine until you try to build the project, then you'll get the error. My latest shadcn-ui version is 0.8.0

### Error:
![image](https://github.com/user-attachments/assets/7bdfe994-7cfb-472e-b9f7-1006bec66283)
